### PR TITLE
add better error handling to oEmbed endpoint

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -48,6 +48,9 @@ class DatawrapperPlugin_Oembed extends DatawrapperPlugin {
     protected function oEmbedEndpoint($app) {
         // Get the parameters from the query-parameters
         $url = urldecode($app->request()->get('url'));
+        if (empty($url)) {
+            return error(400, 'you need to pass a url parameter');
+        }
         $format = $app->request()->get('format');
 
         // Get all the possible patterns for chart urls

--- a/plugin.php
+++ b/plugin.php
@@ -210,7 +210,7 @@ class DatawrapperPlugin_Oembed extends DatawrapperPlugin {
 
     protected static function error($code, $message) {
         global $app;
-        $app->response()->status(501);
+        $app->response()->status($code);
         $app->response()->header('Content-Type', 'application/json;charset=utf-8');
         print json_encode(['error' => $message]);
     }

--- a/plugin.php
+++ b/plugin.php
@@ -78,11 +78,12 @@ class DatawrapperPlugin_Oembed extends DatawrapperPlugin {
             $parsedUrl = parse_url($url, PHP_URL_PATH);
             $id = explode("/", $parsedUrl);
 
-            if (sizeof($id) > 1) {
+            if (sizeof($id) > 1 && strlen($id[1]) == 5) {
                 $id = $id[1];
+                $found = true;
             }
+        }
 
-            $found = true;
         }
 
         // Check that the chart exists

--- a/plugin.php
+++ b/plugin.php
@@ -97,6 +97,11 @@ class DatawrapperPlugin_Oembed extends DatawrapperPlugin {
         // And check that the chart is public
         if (!$chart->isPublic()) return self::error(404, 'chart not found');;
 
+        // make sure that the public url matches the requested url
+        $urlHost = parse_url($url, PHP_URL_HOST);
+        $chartHost = parse_url($chart->getPublicUrl(), PHP_URL_HOST);
+        if ($urlHost != $chartHost) return self::error(404, 'chart not found');
+
         // Get the oEmbed response
         self::chart_oembed($app, $chart);
     }

--- a/plugin.php
+++ b/plugin.php
@@ -90,10 +90,10 @@ class DatawrapperPlugin_Oembed extends DatawrapperPlugin {
 
         // Check that the chart exists
         $chart = ChartQuery::create()->findPK($id);
-        if (!$chart) return ;
+        if (!$chart) return error(404, 'chart not found');
 
         // And check that the chart is public
-        if (!$chart->isPublic()) return;
+        if (!$chart->isPublic()) return error(404, 'chart not found');;
 
         // Get the oEmbed response
         self::chart_oembed($app, $chart);

--- a/plugin.php
+++ b/plugin.php
@@ -84,6 +84,8 @@ class DatawrapperPlugin_Oembed extends DatawrapperPlugin {
             }
         }
 
+        if (!$found) {
+            return error(400, 'this doesn\'t look like a datawrapper chart url');
         }
 
         // Check that the chart exists


### PR DESCRIPTION
this PR adds proper error messages to the oembed api endpoint:

* `400` if parameters `url` or `format` where missing
* `404` if the chart with the given id was not found or not public (we don't want to admit a chart exists if it's not public
* `501` if the requests format isn't json 

I took the liberty to add a new requirement for oembed calls, which is that the **hostname in the provided url must match the hostname we stored in the chart public url**. 

we should discuss this, but I think it makes sense to be strict about this to prevent guessing of chart urls based on the id. it also prevents accidental matches if someone requests an url like `https://example.com/admin` and we happen to have a chart with that id (we do).

