### PR TITLE
Use next public url, not current, in oembed link in published chart <head>

### DIFF
--- a/api.js
+++ b/api.js
@@ -184,8 +184,12 @@ module.exports = {
         if (event.CHART_AFTER_HEAD_HTML) {
             events.on(event.CHART_AFTER_HEAD_HTML, async ({ chart, publish }) => {
                 if (publish) {
+                    const publicUrl = await events.emit(
+                        event.GET_NEXT_PUBLIC_URL,
+                        {chart}
+                    );
                     return `<link rel="alternate" type="application/json+oembed"
-      href="https://${apiDomain}/v3/oembed?url=${chart.public_url}&format=json"
+      href="https://${apiDomain}/v3/oembed?url=${publicUrl}&format=json"
       title="oEmbed" />`;
                 }
             });

--- a/api.js
+++ b/api.js
@@ -189,7 +189,7 @@ module.exports = {
                         event.GET_NEXT_PUBLIC_URL,
                         {chart},
                         { filter: 'first' }
-                    );
+                    )[0];
                     return `<link rel="alternate" type="application/json+oembed"
       href="https://${apiDomain}/v3/oembed?url=${publicUrl}&format=json"
       title="oEmbed" />`;

--- a/api.js
+++ b/api.js
@@ -187,7 +187,8 @@ module.exports = {
                 if (publish) {
                     const publicUrl = await events.emit(
                         event.GET_NEXT_PUBLIC_URL,
-                        {chart}
+                        {chart},
+                        { filter: 'first' }
                     );
                     return `<link rel="alternate" type="application/json+oembed"
       href="https://${apiDomain}/v3/oembed?url=${publicUrl}&format=json"

--- a/api.js
+++ b/api.js
@@ -189,7 +189,7 @@ module.exports = {
                         event.GET_NEXT_PUBLIC_URL,
                         {chart},
                         { filter: 'first' }
-                    )[0];
+                    );
                     return `<link rel="alternate" type="application/json+oembed"
       href="https://${apiDomain}/v3/oembed?url=${publicUrl}&format=json"
       title="oEmbed" />`;

--- a/api.js
+++ b/api.js
@@ -16,8 +16,9 @@ module.exports = {
         const { models } = options;
         const { Chart } = models;
 
-        // register new event type
+        // register new event types
         event.GET_PUBLISHED_URL_PATTERN = 'GET_PUBLISHED_URL_PATTERN';
+        event.GET_NEXT_PUBLIC_URL = 'GET_NEXT_PUBLIC_URL';
 
         const cloudConfig = server.methods.config('plugins')['publish-cloud'];
         const chartDomain = cloudConfig ? cloudConfig.hostname : false;


### PR DESCRIPTION
Sister PR of [this publish-cloud PR](https://github.com/datawrapper/plugin-publish-cloud/pull/18).